### PR TITLE
Fysikmotorn compatibility and final fixes for production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,9 @@ COPY --from=frontend-builder /out/admin /var/www/admin
 # Uncomment when screen frontend is ready
 COPY --from=frontend-builder /out/screen /var/www/screen
 
+# Remove the default nginx site that conflicts
+RUN rm -f /etc/nginx/sites-enabled/default
+
 COPY nginx.conf /etc/nginx/conf.d/app.conf
 
 EXPOSE 80

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -74,8 +74,12 @@ async fn main() -> std::io::Result<()> {
     env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
 
     // Secret key for cookie session store
-    // TODO replace with good key stored somewhere else in production
-    let secret_key = Key::from("hejjakwdjaklwjdlka jwkldjalkwdjalkwjdlkajlkdja klwd231ahwdah widuhalwiudh aliuwhdjlad".as_bytes());
+    let secret_key_string = std::env::var("COOKIE_SECRET_KEY")
+        .unwrap_or_else(|_| {
+            log::warn!("COOKIE_SECRET_KEY not set in environment, using default insecure key mashed key");
+            "hejjakwdjaklwjdlka jwkldjalkwdjalkwjdlkajlkdja klwd231ahwdah widuhalwiudh aliuwhdjlad".to_string()
+        });
+    let secret_key = Key::from(secret_key_string.as_bytes());
     
 
     // initialize DB pool outside of `HttpServer::new` so that it is shared across all workers
@@ -94,7 +98,7 @@ async fn main() -> std::io::Result<()> {
 
     log::info!("saving images at {SLIDE_IMAGE_DIR}");
 
-    log::info!("starting HTTP server at http://localhost:8080");
+    log::info!("starting Actix backend at http://0.0.0.0:8080");
 
 
     HttpServer::new(move || {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -124,7 +124,7 @@ async fn main() -> std::io::Result<()> {
             .wrap(middleware::Logger::default())
             .wrap(
                 SessionMiddleware::builder(CookieSessionStore::default(), secret_key.clone())
-                .cookie_secure(secure_cookies) //TODO set to true in production
+                .cookie_secure(secure_cookies) // Controlled via COOKIE_SECURE env var; should be true in production
                 .build()
                 )
             .wrap(cors)

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -76,12 +76,21 @@ async fn main() -> std::io::Result<()> {
     // Secret key for cookie session store
     let secret_key_string = std::env::var("COOKIE_SECRET_KEY")
         .unwrap_or_else(|_| {
-            log::warn!("COOKIE_SECRET_KEY not set in environment, using default insecure key mashed key");
+            log::warn!("COOKIE_SECRET_KEY not set; using default insecure key mashed key");
             "hejjakwdjaklwjdlka jwkldjalkwdjalkwjdlkajlkdja klwd231ahwdah widuhalwiudh aliuwhdjlad".to_string()
         });
     let secret_key = Key::from(secret_key_string.as_bytes());
     
-
+    // Check if cookies should be sent only over HTTPS
+    let secure_cookies = std::env::var("COOKIE_SECURE")
+        .unwrap_or_else(|_| {
+            log::warn!("COOKIE_SECURE not set; defaulting to false");
+            "false".to_string()
+        })
+        .to_lowercase() == "true";
+    if !secure_cookies {
+        log::warn!("COOKIE_SECURE is false; cookies will be able to be sent over HTTP");
+    }
     // initialize DB pool outside of `HttpServer::new` so that it is shared across all workers
     let pool = initialize_db_pool();
 
@@ -115,7 +124,7 @@ async fn main() -> std::io::Result<()> {
             .wrap(middleware::Logger::default())
             .wrap(
                 SessionMiddleware::builder(CookieSessionStore::default(), secret_key.clone())
-                .cookie_secure(false) //TODO set to true in production
+                .cookie_secure(secure_cookies) //TODO set to true in production
                 .build()
                 )
             .wrap(cors)
@@ -139,11 +148,11 @@ async fn main() -> std::io::Result<()> {
 ///
 /// See more: <https://docs.rs/diesel/latest/diesel/r2d2/index.html>.
 fn initialize_db_pool() -> DbPool {
-    let conn_spec = std::env::var("DATABASE_URL").expect("DATABASE_URL should be set");
+    let conn_spec = std::env::var("DATABASE_URL").expect("DATABASE_URL is not set");
     let manager = r2d2::ConnectionManager::<SqliteConnection>::new(conn_spec);
     r2d2::Pool::builder()
         .build(manager)
-        .expect("database URL should be valid path to SQLite DB file")
+        .expect("DATABASE_URL should be valid path to SQLite DB file")
 }
 
 #[cfg(test)]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     environment:
       - GOOGLE_ID_TOKEN=
       - COOKIE_SECRET_KEY= 
+      - COOKIE_SECURE=false
       - DATABASE_URL=sqlite:///app/data/db/konsol.db
       - SLIDE_IMAGE_DIR=/app/data/slides
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - slides:/app/data/slides
     environment:
       - GOOGLE_ID_TOKEN=
+      - COOKIE_SECRET_KEY= 
       - DATABASE_URL=sqlite:///app/data/db/konsol.db
       - SLIDE_IMAGE_DIR=/app/data/slides
 
@@ -15,9 +16,16 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    restart: unless-stopped
+
+  nginx:
+    image: nginx:latest
+    volumes:
+      - ./outer-nginx.conf:/etc/nginx/conf.d/app.conf:ro
     ports:
       - "80:80"
     depends_on:
+      - web
       - backend
     restart: unless-stopped
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - slides:/app/data/slides
     environment:
       - GOOGLE_ID_TOKEN=
-      - COOKIE_SECRET_KEY= 
+      # - COOKIE_SECRET_KEY= 
       - COOKIE_SECURE=false
       - DATABASE_URL=sqlite:///app/data/db/konsol.db
       - SLIDE_IMAGE_DIR=/app/data/slides

--- a/nginx.conf
+++ b/nginx.conf
@@ -2,12 +2,22 @@ server {
     listen 80;
     server_name f.kth.se _;
 
-    location /konsol/admin {
+    # Redirect /konsol/admin to /konsol/admin/
+    location = /konsol/admin {
+        return 301 /konsol/admin/;
+    }
+
+    location /konsol/admin/ {
         alias /var/www/admin/;
         try_files $uri $uri/ /konsol/admin/index.html;
     }
 
-    location /konsol/screen {
+    # Redirect /konsol/screen to /konsol/screen/
+    location = /konsol/screen {
+        return 301 /konsol/screen/;
+    }
+
+    location /konsol/screen/ {
         alias /var/www/screen/;
         try_files $uri $uri/ /konsol/screen/index.html;
     }

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,27 +1,14 @@
 server {
     listen 80;
-    server_name f.kth.se;
+    server_name f.kth.se _;
 
     location /konsol/admin {
         alias /var/www/admin/;
         try_files $uri $uri/ /konsol/admin/index.html;
     }
 
-
     location /konsol/screen {
         alias /var/www/screen/;
         try_files $uri $uri/ /konsol/screen/index.html;
-    }
-
-    # API proxied to backend
-    location /konsol/api/ {
-        proxy_pass http://backend:8080/;
-        proxy_set_header Host $host$uri;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection $http_connection;
     }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,3 +1,5 @@
+# This is the nginx that serves the files from admin and screen frontends
+# in the web container. This file gets copied into the container at build
 server {
     listen 80;
     server_name f.kth.se _;

--- a/outer-nginx.conf
+++ b/outer-nginx.conf
@@ -10,20 +10,25 @@ server {
         proxy_pass http://backend:8080;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 
     location /konsol/admin {
         proxy_pass http://web:80;
         proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
     }
 
     location /konsol/screen {
         proxy_pass http://web:80;
         proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
     }
 
     location /screen/ {
         proxy_pass http://web:80;
         proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
     }
 }

--- a/outer-nginx.conf
+++ b/outer-nginx.conf
@@ -1,0 +1,29 @@
+# This nginx serves as a reverse proxy (mostly for local debugging / documentation) and 
+# is ran with the included docker-compose.yml. Fysikmotorn has its own nginx instead of this
+server {
+    listen 80 default_server;
+    server_name localhost _;
+
+    location /konsol/api/ {
+        # The backend expects paths without the /konsol/api prefix
+        rewrite ^/konsol/api/(.*)$ /$1 break;
+        proxy_pass http://backend:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    location /konsol/admin {
+        proxy_pass http://web:80;
+        proxy_set_header Host $host;
+    }
+
+    location /konsol/screen {
+        proxy_pass http://web:80;
+        proxy_set_header Host $host;
+    }
+
+    location /screen/ {
+        proxy_pass http://web:80;
+        proxy_set_header Host $host;
+    }
+}


### PR DESCRIPTION
This PR removes the proxying of the backend container through the web container so the containers are now independent of each other.  This makes the project easier to run without an isolated network (like in docker compose), improving compatability with the current setup of Fysikmotorn.

After this PR, the project will require an outer proxy that forwards the correct URL's to the correct container (something which was formerly done by the Nginx in web). The `docker-compose.yml` has been updated to include such a proxy using the config in `outer-nginx.conf`. This `docker-compose.yml` does not completely reflect how the project will be hosted on Fysikmotorn but still serves as a way to test locally and as documentation.

Additionaly, this PR adds environment variables for the cookie key and whether to serve cookies over HTTP or not.